### PR TITLE
Add option to change output path

### DIFF
--- a/splitNSP.py
+++ b/splitNSP.py
@@ -12,7 +12,7 @@ startTime = datetime.now()
 splitSize = 0xFFFF0000 # 4,294,901,760 bytes
 chunkSize = 0x8000 # 32,768 bytes
 
-def splitQuick(filepath):
+def splitQuick(filepath, output_dir=""):
     fileSize = os.path.getsize(filepath)
     info = shutil.disk_usage(os.path.dirname(os.path.abspath(filepath)))
     if info.free < splitSize:
@@ -25,9 +25,14 @@ def splitQuick(filepath):
         return
 
     print('Splitting NSP into {0} parts...\n'.format(splitNum + 1))
-
+    
     # Create directory, delete if already exists
-    dir = filepath[:-4] + '_split.nsp'
+    if output_dir == "":
+        dir = filepath[:-4] + '_split.nsp'
+    else:
+        if output_dir[-4:] != '.nsp':
+            output_dir+= ".nsp"
+        dir = output_dir
     if os.path.exists(dir):
         shutil.rmtree(dir)
     os.makedirs(dir)
@@ -74,7 +79,7 @@ def splitQuick(filepath):
 
     print('\nNSP successfully split!\n')
     
-def splitCopy(filepath):
+def splitCopy(filepath, output_dir=""):
     fileSize = os.path.getsize(filepath)
     info = shutil.disk_usage(os.path.dirname(os.path.abspath(filepath)))
     if info.free < fileSize*2:
@@ -89,7 +94,12 @@ def splitCopy(filepath):
     print('Splitting NSP into {0} parts...\n'.format(splitNum + 1))
 
     # Create directory, delete if already exists
-    dir = filepath[:-4] + '_split.nsp'
+    if output_dir == "":
+        dir = filepath[:-4] + '_split.nsp'
+    else:
+        if output_dir[-4:] != '.nsp':
+            output_dir+= ".nsp"
+        dir = output_dir
     if os.path.exists(dir):
         shutil.rmtree(dir)
     os.makedirs(dir)
@@ -122,6 +132,8 @@ def main():
     parser = argparse.ArgumentParser(description='Split NSP files into FAT32 compatible sizes')
     parser.add_argument('filepath', help='Path to NSP file')
     parser.add_argument('-q', '--quick', action='store_true', help='Splits file in-place without creating a copy. Only requires 4GiB free space to run')
+    parser.add_argument('-o', '--output-dir', type=str, default="",
+                        help="Set alternative output dir")
 
     # Check passed arguments
     args = parser.parse_args()
@@ -135,9 +147,9 @@ def main():
     
     # Split NSP file
     if args.quick:
-        splitQuick(filepath)
+        splitQuick(filepath, args.output_dir)
     else:
-        splitCopy(filepath)
+        splitCopy(filepath, args.output_dir)
 
 if __name__ == "__main__":
     main()

--- a/splitNSP.py
+++ b/splitNSP.py
@@ -27,12 +27,7 @@ def splitQuick(filepath):
     print('Splitting NSP into {0} parts...\n'.format(splitNum + 1))
     
     # Create directory, delete if already exists
-    if output_dir == "":
-        dir = filepath[:-4] + '_split.nsp'
-    else:
-        if output_dir[-4:] != '.nsp':
-            output_dir+= ".nsp"
-        dir = output_dir
+    dir = filepath[:-4] + '_split.nsp'
     if os.path.exists(dir):
         shutil.rmtree(dir)
     os.makedirs(dir)

--- a/splitNSP.py
+++ b/splitNSP.py
@@ -12,7 +12,7 @@ startTime = datetime.now()
 splitSize = 0xFFFF0000 # 4,294,901,760 bytes
 chunkSize = 0x8000 # 32,768 bytes
 
-def splitQuick(filepath, output_dir=""):
+def splitQuick(filepath):
     fileSize = os.path.getsize(filepath)
     info = shutil.disk_usage(os.path.dirname(os.path.abspath(filepath)))
     if info.free < splitSize:
@@ -131,8 +131,9 @@ def main():
     # Arg parser for program options
     parser = argparse.ArgumentParser(description='Split NSP files into FAT32 compatible sizes')
     parser.add_argument('filepath', help='Path to NSP file')
-    parser.add_argument('-q', '--quick', action='store_true', help='Splits file in-place without creating a copy. Only requires 4GiB free space to run')
-    parser.add_argument('-o', '--output-dir', type=str, default="",
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-q', '--quick', action='store_true', help='Splits file in-place without creating a copy. Only requires 4GiB free space to run')
+    group.add_argument('-o', '--output-dir', type=str, default="",
                         help="Set alternative output dir")
 
     # Check passed arguments
@@ -147,7 +148,7 @@ def main():
     
     # Split NSP file
     if args.quick:
-        splitQuick(filepath, args.output_dir)
+        splitQuick(filepath)
     else:
         splitCopy(filepath, args.output_dir)
 


### PR DESCRIPTION
Added the '-o' flag to the tool, in order to directly write the split nsp file to the SD card, rather than writing the split files to disk, then copying it to SD card